### PR TITLE
Improve factorize!, type pretty-printing, getindex and fix other issues

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,9 +4,9 @@ version = "2.0.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-Requires = "ae029012-a4dd-5104-9daa-d747884805df" 
-StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 Requires = "1"
@@ -14,10 +14,10 @@ StatsBase = "0.33"
 julia = "1.3"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-PooledArrays = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
+PooledArrays = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "CUDA", "PooledArrays", "CategoricalArrays"]

--- a/src/FixedEffects.jl
+++ b/src/FixedEffects.jl
@@ -5,6 +5,7 @@ module FixedEffects
 ## Dependencies
 ##
 ##############################################################################
+using Base: @propagate_inbounds
 using LinearAlgebra
 using StatsBase
 using Requires

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-tests = ["solve.jl"]
+tests = ["types.jl", "solve.jl"]
 println("Running tests:")
 
 for test in tests

--- a/test/types.jl
+++ b/test/types.jl
@@ -1,0 +1,71 @@
+using Test
+using FixedEffects
+using FixedEffects: GroupedArray, group, factorize!
+using StatsBase
+import Base: ==
+
+==(x::FixedEffect{R,I}, y::FixedEffect{R,I}) where {R,I} =
+    x.refs == y.refs && x.interaction == y.interaction && x.n == y.n
+
+==(g1::GroupedArray{N}, g2::GroupedArray{N}) where N =
+    g1.refs == g2.refs && g1.n == g2.n
+
+@testset "FixedEffect" begin
+    fe1 = FixedEffect(1:10)
+    @test sprint(show, fe1) == "Fixed Effects"
+    @test sprint(show, MIME("text/plain"), fe1) == """
+        Fixed Effects:
+          refs (10-element Array{UInt32,1}):
+            [1, 2, 3, 4, 5, ... ]
+          interaction (UnitWeights):
+            none"""
+    
+    fe2 = FixedEffect(1:10, interaction=fill(1.23456789, 10))
+    @test sprint(show, MIME("text/plain"), fe2) == """
+        Fixed Effects:
+          refs (10-element Array{UInt32,1}):
+            [1, 2, 3, 4, 5, ... ]
+          interaction (10-element Array{Float64,1}):
+            [1.23457, 1.23457, 1.23457, 1.23457, 1.23457, ... ]"""
+
+    @test_throws DimensionMismatch FixedEffect(1:10, interaction=fill(1, 5))
+
+    @test size(fe1) == (10,)
+    @test length(fe1) == 10
+    @test eltype(fe1) == Int
+    @test eltype(fe2) == Float64
+
+    @test fe1[:] === fe1
+    subfe1 = fe1[[1,2]]
+    @test subfe1.refs == fe1.refs[1:2]
+    @test subfe1.interaction == uweights(2)
+    @test subfe1 == fe1[1:2]
+    @test subfe1 == fe1[fe1.refs.<=2]
+    @test_throws MethodError fe1[[1 2]]
+
+    subfe2 = fe2[[1,2]]
+    @test subfe2.refs == fe2.refs[1:2]
+    @test subfe2.interaction == fe2.interaction[1:2]
+    @test subfe2 == fe2[1:2]
+    @test subfe2 == fe2[fe2.refs.<=2]
+    @test_throws MethodError fe2[[1 2]]
+end
+
+@testset "GroupedArray" begin
+    N = 10
+    a1 = collect(1:N)
+    g1 = group(a1)
+    @test g1 == GroupedArray(collect(UInt32, 1:N), N)
+    @test size(g1) == (N,)
+    @test length(g1) == N
+    @test g1[1] == UInt32(1)
+    @test g1[1:2] == [UInt32(1), UInt32(2)]
+    @test g1[g1.<=2] == g1[[1,2]] == g1[1:2]
+
+    a2 = [1,2]
+    @test_throws DimensionMismatch group(a1, a2)
+
+    a = rand(N)
+    g = group(a)
+    @test factorize!(g) == g
+end


### PR DESCRIPTION
I went through a portion of the source code and made the following changes (with some tests included).

### Enhancement

1. Replace `factorize!` with a more efficient implementation (see benchmark results and more details at the bottom).
2. Improve the methods of `show` for `FixedEffect`.
3. Improve `getindex` for `FixedEffect` and add the methods for `GroupedArray`.

### Bug Fixes

1. `DimensionError` does not exist. It should be `DimensionMismatch`.
2. `eltype(fe::FixedEffect) = eltype(I)` is wrong (`I` is something else without the type parameters).
3. `size(g::GroupedArray)` was not defined. This causes error when trying to show `g`.

### Minor Changes

1. The type of the object returned by `get(invpool, x, 0)` can be either `UInt32` or `Int64`. For operations inside such a tight loop, it seems to be slightly better to only have `UInt32`.
2. Remove the redundant `has_missing` inside `group`.
3. Define `size` for `FixedEffect`.
4. Packages listed in `Project.toml` did not follow alphabetical order. `Pkg` will want to correct this order when doing something with the package environment.

## Additional Details

### Changes on `factorize!`

1. There is no need to first find the unique values before relabeling. One loop is enough and the dictionary will handle that, just like how things work with `group`. (`Dict` is fast for telling whether an object has been met before.)
2. I did a rough benchmark with results shown below:
```julia
using BenchmarkTools
using FixedEffects: GroupedArray, group, factorize!
using StatsBase

const n = 10000000
const a = Vector{Union{Float64, Missing}}(undef, n)
sample!(1:50000, a)
a[500:500:n] .= missing

function old_factorize!(x::GroupedArray{N}) where {N}
	refs = x.refs
	uu = sort!(unique(refs))
	has_missing = uu[1] == 0
	ngroups = length(uu) - has_missing
	dict = Dict{UInt32, UInt32}(zip(uu, UInt32(1-has_missing):UInt32(ngroups)))
	for i in eachindex(refs)
		refs[i] = dict[refs[i]]
	end
	GroupedArray{N}(refs, ngroups)
end

@benchmark old_factorize!(g) setup=(g=group(a))
#= Old factorize!
BenchmarkTools.Trial: 
  memory estimate:  5.17 MiB
  allocs estimate:  82
  --------------
  minimum time:     167.921 ms (0.00% GC)
  median time:      174.756 ms (0.00% GC)
  mean time:        174.487 ms (0.11% GC)
  maximum time:     179.650 ms (0.00% GC)
  --------------
  samples:          17
  evals/sample:     1
=#

@benchmark factorize!(g) setup=(g=group(a))
#= New factorize!
BenchmarkTools.Trial: 
  memory estimate:  3.00 MiB
  allocs estimate:  35
  --------------
  minimum time:     79.639 ms (0.00% GC)
  median time:      81.469 ms (0.00% GC)
  mean time:        83.239 ms (0.00% GC)
  maximum time:     93.849 ms (0.00% GC)
  --------------
  samples:          24
  evals/sample:     1
=#

# Compare performance with group (factorize! should be faster than group)
@benchmark group($a)
#=
BenchmarkTools.Trial: 
  memory estimate:  42.82 MiB
  allocs estimate:  38
  --------------
  minimum time:     120.100 ms (0.00% GC)
  median time:      124.897 ms (0.00% GC)
  mean time:        128.562 ms (3.36% GC)
  maximum time:     180.381 ms (31.43% GC)
  --------------
  samples:          39
  evals/sample:     1
=#
```

### Changes on `show(io::IO, fe::FixedEffect)`

1. It is better to only show something short with this method. (It is used when `fe` is an element for some other container.) The additional details can be printed with `show(io::IO, ::MIME"text/plain", fe::FixedEffect)`. This method is used when the result is directly printed to `REPL`.
2. There was an extra newline from the last `println`. That's why `print(io, '\n', ...)` is often used.
