### PR TITLE
Update FixedEffect.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FixedEffects"
 uuid = "c8885935-8500-56a7-9867-7708b20db0eb"
-version = "2.0.5"
+version = "2.0.6"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FixedEffect.jl
+++ b/src/FixedEffect.jl
@@ -79,13 +79,13 @@ function _group(xs, ::Nothing)
 	refs = Array{UInt32}(undef, size(xs))
 	invpool = Dict{eltype(xs), UInt32}()
 	n = UInt32(0)
-	z = UInt32(0)
-	@inbounds for i in eachindex(xs)
-		x = xs[i]
+	i = UInt32(0)
+	@inbounds for x in xs
+		i += 1
 		if x === missing
 			refs[i] = 0
 		else
-			lbl = get(invpool, x, z)
+			lbl = get(invpool, x, UInt32(0))
 			if !iszero(lbl)
 				refs[i] = lbl
 			else


### PR DESCRIPTION
Handles the fact that `eachindex` does not necessarily returns integer (e.g. SentinelArrays)