### PR TITLE
allow julia 1.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ GroupedArrays = "6407cd72-fade-4a84-8a1e-56e431fc1533"
 [compat]
 StatsBase = "0.33, 0.34"
 GroupedArrays = "0.3"
-julia = "1.9"
+julia = ">= 1.9"
 
 [extensions]
 CUDAExt = "CUDA"

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ GroupedArrays = "6407cd72-fade-4a84-8a1e-56e431fc1533"
 [compat]
 StatsBase = "0.33, 0.34"
 GroupedArrays = "0.3"
-julia = ">= 1.9"
+julia = "^1.9"
 
 [extensions]
 CUDAExt = "CUDA"


### PR DESCRIPTION
On the CI, "nightly" now points to Julia 1.10, which means that an older version of FixedEffects.jl is being used, which means that tests fail etc...