### PR TITLE
Relax Julia compat version and `solve_residuals!` method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,19 +15,19 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.9' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
+          - '1.6' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
           - '1' # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
         os:
           - ubuntu-latest
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:
@@ -40,7 +40,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3
         with:
           file: lcov.info
 

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ GroupedArrays = "6407cd72-fade-4a84-8a1e-56e431fc1533"
 [compat]
 StatsBase = "0.33, 0.34"
 GroupedArrays = "0.3"
-julia = "1.9"
+julia = "1.6"
 
 [extensions]
 CUDAExt = "CUDA"

--- a/Project.toml
+++ b/Project.toml
@@ -24,10 +24,10 @@ Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
 [extras]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PooledArrays = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["CategoricalArrays", "CUDA", "Metal", "PooledArrays", "Test"]
+test = ["CategoricalArrays", "CUDA", "Pkg", "PooledArrays", "Test"]
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FixedEffects"
 uuid = "c8885935-8500-56a7-9867-7708b20db0eb"
-version = "2.3.1"
+version = "2.4.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/AbstractFixedEffectSolver.jl
+++ b/src/AbstractFixedEffectSolver.jl
@@ -80,6 +80,9 @@ function solve_residuals!(r::AbstractVector{<:Real}, feM::AbstractFixedEffectSol
 end
 
 # A fallback method for collections of x
+# The container for data columns does not have to be a vector
+# This allows the use of iterators and tuples for xs in downstream packages
+# See https://github.com/FixedEffects/FixedEffects.jl/pull/65
 function solve_residuals!(xs, feM::AbstractFixedEffectSolver; progress_bar = true, kwargs...)
     iterations = Int[]
     convergeds = Bool[]

--- a/src/AbstractFixedEffectSolver.jl
+++ b/src/AbstractFixedEffectSolver.jl
@@ -79,6 +79,7 @@ function solve_residuals!(r::AbstractVector{<:Real}, feM::AbstractFixedEffectSol
 	return r, iter, converged
 end
 
+# A fallback method for collections of x
 function solve_residuals!(xs, feM::AbstractFixedEffectSolver; progress_bar = true, kwargs...)
     iterations = Int[]
     convergeds = Bool[]

--- a/src/AbstractFixedEffectSolver.jl
+++ b/src/AbstractFixedEffectSolver.jl
@@ -79,7 +79,7 @@ function solve_residuals!(r::AbstractVector{<:Real}, feM::AbstractFixedEffectSol
 	return r, iter, converged
 end
 
-function solve_residuals!(xs::AbstractVector{<: AbstractVector}, feM::AbstractFixedEffectSolver; progress_bar = true, kwargs...)
+function solve_residuals!(xs, feM::AbstractFixedEffectSolver; progress_bar = true, kwargs...)
     iterations = Int[]
     convergeds = Bool[]
     bar = MiniProgressBar(header = "Demean Variables:", color = Base.info_color(), percentage = false, max = length(xs))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,15 @@
 tests = ["types.jl", "solve.jl"]
 println("Running tests:")
 
-using Test, StatsBase, CUDA, Metal, FixedEffects, PooledArrays, CategoricalArrays
+# A work around for tests to run on older versions of Julia
+using Pkg
+if VERSION >= v"1.8"
+	Pkg.add("Metal")
+	using Metal
+end
+
+using Test, StatsBase, CUDA, FixedEffects, PooledArrays, CategoricalArrays
+
 for test in tests
 	try
 		include(test)


### PR DESCRIPTION
Thank you working on this package! I have two issues that I would wish to be resolved here.

1) It seems strange that somehow the minimum Julia version was changed to v1.9 with https://github.com/FixedEffects/FixedEffects.jl/pull/56. This seems unnecessary to me and also undesirable. With FixedEffectModels.jl now requiring FixedEffects.jl v2.3, all packages that directly or indirectly deals with fixed effects now requires Julia v1.9 to be paired with the latest versions of the two. This sounds way too much at least for the recent years.

2) A related issue is that the type restrictions for `solve_residuals!` seem to be too stringent. I would suggest having a fallback method as what I have did here that does not restrict the type of `xs` at all. If something wrong is passed to the method, then an error will be thrown anyway when the loop inside this fallback method iterate over `xs` and call other methods of `solve_residuals!`.

Edit: I see that Metal.jl would cause some problem. But, the GPU part could be ignored if the Julia version is too old.