### PR TITLE
Fix Metal GPU

### DIFF
--- a/src/AbstractFixedEffectSolver.jl
+++ b/src/AbstractFixedEffectSolver.jl
@@ -172,7 +172,7 @@ function FixedEffects.solve_coefficients!(r::AbstractVector, feM::AbstractFixedE
 	if !(feM.weights isa UnitWeights)
 		feM.b .*= sqrt.(feM.weights)
 	end
-	fill!(feM.x, 0.0)
+	fill!(feM.x, zero(T))
 	x, ch = lsmr!(feM.x, feM.m, feM.b, feM.v, feM.h, feM.hbar; atol = tol, btol = tol, maxiter = maxiter)
 	for (x, scale) in zip(feM.x.x, feM.m.scales)
 		x .*=  scale

--- a/src/FixedEffectCoefficients.jl
+++ b/src/FixedEffectCoefficients.jl
@@ -1,4 +1,4 @@
-# Define methods used in LSMR
+e# Define methods used in LSMR
 
 ##############################################################################
 ## 
@@ -28,14 +28,14 @@ end
 
 function Base.fill!(fecoefs::FixedEffectCoefficients, α::Number)
 	for x in fecoefs.x
-		fill!(x, α)
+		fill!(x, eltype(fecoefs)(α))
 	end
 	return fecoefs
 end
 
 function LinearAlgebra.rmul!(fecoefs::FixedEffectCoefficients, α::Number)
 	for x in fecoefs.x
-		rmul!(x, α)
+		rmul!(x, eltype(fecoefs)(α))
 	end
 	return fecoefs
 end


### PR DESCRIPTION
`solve_coefficients!` fails on the GPU because it attempts to set `feM.x` to `0.0`, which triggers an error on certain platforms (Metal). 